### PR TITLE
Update tl_flipbook.php

### DIFF
--- a/src/Resources/contao/dca/tl_flipbook.php
+++ b/src/Resources/contao/dca/tl_flipbook.php
@@ -135,7 +135,7 @@ $GLOBALS['TL_DCA']['tl_flipbook'] = array
             'label' => &$GLOBALS['TL_LANG']['tl_flipbook']['alias'],
             'inputType' => 'text',
             'eval' => array('rgxp' => 'alias', 'doNotCopy' => true, 'maxlength' => 128, 'tl_class' => 'w50'),
-            'sql' => "varchar(128) COLLATE utf8_bin NOT NULL default ''"
+            'sql' => "varchar(255) BINARY NOT NULL default ''"
         ),
         'flipbook_id' => array(
             'label' => &$GLOBALS['TL_LANG']['tl_flipbook']['flipbook_id'],

--- a/src/Resources/contao/dca/tl_flipbook.php
+++ b/src/Resources/contao/dca/tl_flipbook.php
@@ -135,7 +135,7 @@ $GLOBALS['TL_DCA']['tl_flipbook'] = array
             'label' => &$GLOBALS['TL_LANG']['tl_flipbook']['alias'],
             'inputType' => 'text',
             'eval' => array('rgxp' => 'alias', 'doNotCopy' => true, 'maxlength' => 128, 'tl_class' => 'w50'),
-            'sql' => "varchar(255) BINARY NOT NULL default ''"
+            'sql' => "varchar(128) BINARY NOT NULL default ''"
         ),
         'flipbook_id' => array(
             'label' => &$GLOBALS['TL_LANG']['tl_flipbook']['flipbook_id'],


### PR DESCRIPTION
Das behebt das Problem aus https://github.com/duncrow-gmbh/flipbert/issues/11

Der Fehler tritt wahrscheinlich erst ab Maria-DB 10 auf. Die Änderung ist analog der SQL-Definition aus dem Core für den Alias in z.B. tl_article